### PR TITLE
new game overrides and new archlist additions

### DIFF
--- a/archlist.json
+++ b/archlist.json
@@ -31,5 +31,17 @@
     "Bastion": "i386+x86_64",
     "CultistSimulator": "i386+x86_64",
     "Warhammer40000GladiusRelicsofWar": "x86_64",
-    "DeadCells": "x86_64"
+    "DeadCells": "x86_64",
+    "Xenonauts": "i386",
+    "Dex": "i386",
+    "Broforce": "i386+x86_64",
+    "Jotun": "i386+x86_64",
+    "LoversInADangerousSpacetime": "i386+x86_64",
+    "Oxenfree": "i386+x86_64",
+    "PrisonArchitect": "i386+x86_64",
+    "Starbound": "x86_64",
+    "StardewValley": "i386+x86_64",
+    "SunlessSea": "i386+x86_64",
+    "ThimbleweedPark": "x86_64",
+    "WorldofGoo": "i386+x86_64"
 }

--- a/overrides/configure-Broforce
+++ b/overrides/configure-Broforce
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd /app/game/game/
+
+mv DebugConfig.txt DebugConfig.txt-orig
+ln -s /var/data/DebugConfig.txt /app/game/game/DebugConfig.txt
+ln -s /var/data/Saves .

--- a/overrides/configure-Starbound
+++ b/overrides/configure-Starbound
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd /app/game/game/
+
+ln -s /var/data/storage .

--- a/overrides/readme-Broforce
+++ b/overrides/readme-Broforce
@@ -1,0 +1,1 @@
+Game tries to save savegames and configuration in game dir, instead of home directory.

--- a/overrides/readme-Starbound
+++ b/overrides/readme-Starbound
@@ -1,0 +1,1 @@
+Game tries to save savegames and configuration in game dir, instead of home directory.

--- a/overrides/readme-StardewValley
+++ b/overrides/readme-StardewValley
@@ -1,0 +1,1 @@
+Game is not compatible with modern terminfo files. Set xterm as TERM to get the game to start

--- a/overrides/starter-Broforce
+++ b/overrides/starter-Broforce
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ ! -d /var/data/Saves ]
+then
+    mkdir /var/data/Saves
+    cp /app/game/game/DebugConfig.txt-orig /var/data/DebugConfig.txt
+fi
+
+cd /app/game/
+./start.sh

--- a/overrides/starter-Starbound
+++ b/overrides/starter-Starbound
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ ! -d /var/data/storage ]
+then
+    mkdir /var/data/storage
+fi
+
+cd /app/game/
+./start.sh

--- a/overrides/starter-StardewValley
+++ b/overrides/starter-StardewValley
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd /app/game/
+TERM=xterm ./start.sh


### PR DESCRIPTION
Overrides for Starbound and StardewValley. Starbound writes to it's game directory.
StardewValley runs on the current runtime but using the 18.08 runtime this game triggers a bug in the mono runtime shipped with it. A workaround is to set TERM to xterm.

edit: Added Broforce

edit2: added more games to archlist