### PR TITLE
Update shared-modules to include GLU v9.0.1

### DIFF
--- a/com.gog.Template.json
+++ b/com.gog.Template.json
@@ -59,6 +59,6 @@
                 }
             ]
         },
-        "shared-modules/glu/glu-9.0.0.json"
+        "shared-modules/glu/glu-9.json"
     ]
 }


### PR DESCRIPTION
This PR moves `shared-modules` to its current master to use the newer GLU 9.0.1. Older versions of GLU did no longer compile with modern compilers.