### PR TITLE
Remove custom branch option

### DIFF
--- a/com.gog.Template.json
+++ b/com.gog.Template.json
@@ -1,6 +1,5 @@
 {
     "app-id": "com.gog.GAMENAME",
-    "branch": "master",
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "19.08",
     "sdk": "org.freedesktop.Sdk",

--- a/com.gog.i386-compat.Template.json
+++ b/com.gog.i386-compat.Template.json
@@ -1,6 +1,5 @@
 {
     "app-id": "com.gog.GAMENAME",
-    "branch": "master",
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "19.08",
     "sdk": "org.freedesktop.Sdk",

--- a/json-maker.py
+++ b/json-maker.py
@@ -12,7 +12,7 @@ DEFAULT_TEMPLATE = "com.gog.Template.json"
 I386_COMPAT_TEMPLATE = "com.gog.i386-compat.Template.json"
 
 
-def getGameInfo(installer, argname, argbranch, argarch, archdata):
+def getGameInfo(installer, argname, argarch, archdata):
     gameinfo = {}
     with zipfile.ZipFile(installer, 'r') as myzip:
         with myzip.open('data/noarch/gameinfo') as myfile:
@@ -20,7 +20,6 @@ def getGameInfo(installer, argname, argbranch, argarch, archdata):
             gameinfo['orig-name'] = tmplist[0]
             gameinfo['gogversion'] = tmplist[1]
             gameinfo['version'] = tmplist[2]
-            gameinfo['branch'] = argbranch
         gogversiondate = myzip.getinfo('data/noarch/gameinfo').date_time
         gameinfo['gogversiondate'] = "{}-{}-{}".format(gogversiondate[0], gogversiondate[1], gogversiondate[2])
 
@@ -96,10 +95,6 @@ def parseArgs() -> argparse.Namespace:
         default=[],
         help="Additional installers to run (e.g. DLC). " +
              "Can be used multiple times.")
-    parser.add_argument(
-        '--branch',
-        help="Branch name.",
-        default='master')
     parser.add_argument(
         '--arch',
         help="Arch of game.",
@@ -191,14 +186,12 @@ def main() -> None:
     gameinfo = getGameInfo(
             args.installer,
             args.name,
-            args.branch,
             args.arch,
             archdata)
 
     jsondata = readTemplate(gameinfo['arch'], args.template)
 
     jsondata['app-id'] = gameinfo['app-id']
-    jsondata['branch'] = gameinfo['branch']
 
     startoverride = args.startoverride
     configureoverride = args.configureoverride


### PR DESCRIPTION
For games on GOG new versions simply get released, there are no different branches e.g. for beta releases afaik. So it's easiest to just utilize flatpak-builder's default (master) by simply writing nothing into the manifest. This PR removes code related to Flatpak branches.

For development or other special purposes there is still the `--default-branch` command line option of flatpak-builder which overrides the [default-branch value](https://docs.flatpak.org/en/latest/flatpak-builder-command-reference.html#idm419) of the manifest.